### PR TITLE
[FIX] Improve error handling and null safety in PageNotFoundFinder | Use Request Domain if available 

### DIFF
--- a/src/HC.PageNotFoundManager/ContentFinders/PageNotFoundFinder.cs
+++ b/src/HC.PageNotFoundManager/ContentFinders/PageNotFoundFinder.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using HC.PageNotFoundManager.Config;
 using HC.PageNotFoundManager.Extensions;
 using HC.PageNotFoundManager.Models;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Routing;
@@ -18,6 +19,8 @@ public class PageNotFoundFinder : IContentLastChanceFinder
     private readonly IPageNotFoundService config;
     private readonly PageNotFoundManagerSettings pageNotFoundManagerSettings;
 
+    private readonly ILogger<PageNotFoundFinder> logger;
+
     private readonly IDomainService domainService;
 
     private readonly IUmbracoContextFactory umbracoContextFactory;
@@ -30,7 +33,8 @@ public class PageNotFoundFinder : IContentLastChanceFinder
         IDocumentUrlService documentUrlService,
         IDocumentNavigationQueryService documentNavigationQueryService,
         IPageNotFoundService config,
-        IOptions<PageNotFoundManagerSettings> pageNotFoundManagerSettings)
+        IOptions<PageNotFoundManagerSettings> pageNotFoundManagerSettings,
+        ILogger<PageNotFoundFinder> logger)
     {
         this.domainService = domainService ?? throw new ArgumentNullException(nameof(domainService));
         this.umbracoContextFactory =
@@ -39,75 +43,72 @@ public class PageNotFoundFinder : IContentLastChanceFinder
         this.documentNavigationQueryService = documentNavigationQueryService;
         this.config = config ?? throw new ArgumentNullException(nameof(config));
         this.pageNotFoundManagerSettings = pageNotFoundManagerSettings.Value ?? throw new ArgumentNullException(nameof(pageNotFoundManagerSettings));
+        this.logger = logger;
     }
 
     public async Task<bool> TryFindContent(IPublishedRequestBuilder request)
     {
-        string uri = request.AbsolutePathDecoded;
-        // a route is "/path/to/page" when there is no domain, and "123/path/to/page" when there is a domain, and then 123 is the ID of the node which is the root of the domain
-        //get domain name from Uri
-        // find umbraco home node for uri's domain, and get the id of the node it is set on
-
-        if (pageNotFoundManagerSettings.ExcludePaths.Any(excludePath => uri.StartsWith(excludePath, StringComparison.OrdinalIgnoreCase)))
-            return false;
-
-        var domains = (await domainService.GetAllAsync(true)).ToList();
-        var domainRoutePrefixId = string.Empty;
-        if (domains.Count != 0)
+        try
         {
-            //A domain can be defined with or without http(s) so we neet to check for both cases.
-            IDomain? domain = null;
-            foreach (var currentDomain in domains)
+            string uri = request.AbsolutePathDecoded;
+            // a route is "/path/to/page" when there is no domain, and "123/path/to/page" when there is a domain, and then 123 is the ID of the node which is the root of the domain
+            //get domain name from Uri
+            // find umbraco home node for uri's domain, and get the id of the node it is set on
+
+            if (pageNotFoundManagerSettings.ExcludePaths.Any(excludePath => uri.StartsWith(excludePath, StringComparison.OrdinalIgnoreCase)))
+                return false;
+
+            string? domainRoutePrefixId;
+            if (request.Domain is null)
             {
-                if (IsCurrentDomainIsAbsoluteAndCurrentRequestStartsWithDomain(request, currentDomain)
-                    || CurrentRequestStartsWithDomainAndDomainDoesntStartWithHttp(request, currentDomain))
-                {
-                    domain = currentDomain;
-                    break;
-                }
+                domainRoutePrefixId = await GetDomain(request);
+            }
+            else
+            {
+                domainRoutePrefixId = request.Domain.ContentId.ToString();
             }
 
-            if (domain != null)
-            {
-                // the domain has a RootContentId that we can use as the prefix.
-                domainRoutePrefixId = domain.RootContentId.ToString();
-            }
-        }
+            using var umbracoContext = umbracoContextFactory.EnsureUmbracoContext();
 
-        using (var umbracoContext = umbracoContextFactory.EnsureUmbracoContext())
-        {
-            var documentKey = documentUrlService.GetDocumentKeyByRoute(domainRoutePrefixId + uri, request.Culture, null, false);            
-            while (documentKey == null)
+            var documentKey = documentUrlService.GetDocumentKeyByRoute(domainRoutePrefixId + uri, request.Culture, null, false);
+            while (documentKey == null && uri.Length > 0)
             {
                 uri = uri.Remove(uri.Length - 1, 1);
                 documentKey = documentUrlService.GetDocumentKeyByRoute(domainRoutePrefixId + uri, request.Culture, null, false);
             }
 
             var contentNode = documentKey != null ? umbracoContext.UmbracoContext.Content.GetById(documentKey!.Value) : null;
+            if (contentNode == null)
+            {
+                return false;
+            }
 
-            var nfp = config.GetNotFoundPage(documentKey ?? Guid.Empty);
-
+            var nfp = config.GetNotFoundPage(documentKey!.Value);
             var nfpKey = nfp?.Explicit404 ?? nfp?.Inherited404?.Explicit404 ?? Guid.Empty;
             var content = umbracoContext.UmbracoContext.Content.GetById(nfpKey);
 
-            while (content == null && contentNode.TryGetParent(documentNavigationQueryService, 
+            while (content == null && contentNode.TryGetParent(documentNavigationQueryService,
                 umbracoContext.UmbracoContext.Content, out var parent) && parent != null)
             {
                 contentNode = parent;
-
-                if (contentNode == null)
-                {
-                    return false;
-                }
-
                 nfp = config.GetNotFoundPage(contentNode.Key);
                 nfpKey = nfp?.Explicit404 ?? nfp?.Inherited404?.Explicit404 ?? Guid.Empty;
                 content = umbracoContext.UmbracoContext.Content.GetById(nfpKey);
-            }            
+            }
+
+            if (content == null)
+            {
+                return false;
+            }
 
             request.SetResponseStatus(404);
             request.SetPublishedContent(content);
             return true;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "An error occurred in PageNotFoundFinder while trying to find content for request {RequestUri}", request.Uri);
+            return false;
         }
     }
 
@@ -125,5 +126,34 @@ public class PageNotFoundFinder : IContentLastChanceFinder
     {
         return currentDomain.DomainName.StartsWith("http", StringComparison.InvariantCultureIgnoreCase)
                && request.Uri.AbsoluteUri.StartsWith(currentDomain.DomainName.ToLower(), StringComparison.InvariantCultureIgnoreCase);
+    }
+
+    //Does not handle relative Domains.
+    private async Task<string?> GetDomain(IPublishedRequestBuilder request)
+    {
+        var domains = (await domainService.GetAllAsync(true)).ToList();
+
+        if (domains.Count != 0)
+        {
+            //A domain can be defined with or without http(s) so we neet to check for both cases.
+            IDomain? domain = null;
+            foreach (var currentDomain in domains)
+            {
+                if (IsCurrentDomainIsAbsoluteAndCurrentRequestStartsWithDomain(request, currentDomain)
+                    || CurrentRequestStartsWithDomainAndDomainDoesntStartWithHttp(request, currentDomain))
+                {
+                    domain = currentDomain;
+                    break;
+                }
+            }
+
+            if (domain != null)
+            {
+                // the domain has a RootContentId that we can use as the prefix.
+                return domain.RootContentId.ToString();
+            }
+        }
+
+        return string.Empty;
     }
 }


### PR DESCRIPTION
  - Add try-catch wrapper with logging for all exceptions
  - Add early return when contentNode is null to prevent NullReferenceException
  - Use Request Domain data if present
  - Extract domain resolution logic to separate GetDomain method
  - Fix URI length check to prevent infinite loop
  - Add logger dependency injection and error logging
  - Improve null safety throughout the content finding logic