### PR TITLE
Add diagnostic logging to content finder and config service

### DIFF
--- a/src/HC.PageNotFoundManager/Config/PageNotFoundConfigService.Log.cs
+++ b/src/HC.PageNotFoundManager/Config/PageNotFoundConfigService.Log.cs
@@ -1,0 +1,37 @@
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace HC.PageNotFoundManager.Config;
+
+public partial class PageNotFoundConfigService
+{
+    [LoggerMessage(Level = LogLevel.Debug, Message = "PageNotFoundManager: Config lookup by ID {NodeId} — node not found in content cache")]
+    private partial void LogNodeNotFoundById(int nodeId);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "PageNotFoundManager: Config lookup by key {NodeKey} — node not found in content cache")]
+    private partial void LogNodeNotFoundByKey(Guid nodeKey);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "PageNotFoundManager: Config found for {NodeKey} (\"{NodeName}\"): Explicit404={Explicit404}")]
+    private partial void LogConfigFound(Guid nodeKey, string nodeName, Guid? explicit404);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "PageNotFoundManager: No explicit config for {NodeKey} (\"{NodeName}\"), will check ancestors")]
+    private partial void LogNoConfigForNode(Guid nodeKey, string nodeName);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "PageNotFoundManager: Cache refreshed")]
+    private partial void LogCacheRefresh();
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "PageNotFoundManager: Setting 404 page for parent {ParentKey} to {PageNotFoundKey}")]
+    private partial void LogSettingNotFoundPage(Guid parentKey, Guid pageNotFoundKey);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "PageNotFoundManager: Created 404 config for {ParentKey} → {PageNotFoundKey}")]
+    private partial void LogConfigCreated(Guid parentKey, Guid pageNotFoundKey);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "PageNotFoundManager: Deleted 404 config for {ParentKey}")]
+    private partial void LogConfigDeleted(Guid parentKey);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "PageNotFoundManager: Updated 404 config for {ParentKey} → {PageNotFoundKey}")]
+    private partial void LogConfigUpdated(Guid parentKey, Guid pageNotFoundKey);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "PageNotFoundManager: Loaded {Count} 404 config(s) from database")]
+    private partial void LogLoadedFromDb(int count);
+}

--- a/src/HC.PageNotFoundManager/Config/PageNotFoundConfigService.cs
+++ b/src/HC.PageNotFoundManager/Config/PageNotFoundConfigService.cs
@@ -1,9 +1,10 @@
-﻿using HC.PageNotFoundManager.Extensions;
+using HC.PageNotFoundManager.Extensions;
 using HC.PageNotFoundManager.Models;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.PublishedCache;
@@ -14,27 +15,29 @@ using Umbraco.Extensions;
 
 namespace HC.PageNotFoundManager.Config;
 
-public class PageNotFoundConfigService : IPageNotFoundService
+public partial class PageNotFoundConfigService : IPageNotFoundService
 {
     private const string CacheKey = "PageNotFoundConfig";
 
     private readonly IAppPolicyCache appPolicyCache;
     private readonly IDocumentNavigationQueryService documentNavigationQueryService;
     private readonly IScopeProvider scopeProvider;
-
     private readonly IUmbracoContextFactory umbracoContextFactory;
+    private readonly ILogger<PageNotFoundConfigService> logger;
 
     public PageNotFoundConfigService(
         IScopeProvider scopeProvider,
         IUmbracoContextFactory umbracoContextFactory,
         IAppPolicyCache appPolicyCache,
-        IDocumentNavigationQueryService documentNavigationQueryService)
+        IDocumentNavigationQueryService documentNavigationQueryService,
+        ILogger<PageNotFoundConfigService> logger)
     {
         this.scopeProvider = scopeProvider ?? throw new ArgumentNullException(nameof(scopeProvider));
         this.umbracoContextFactory =
             umbracoContextFactory ?? throw new ArgumentNullException(nameof(umbracoContextFactory));
         this.appPolicyCache = appPolicyCache ?? throw new ArgumentNullException(nameof(appPolicyCache));
         this.documentNavigationQueryService = documentNavigationQueryService;
+        this.logger = logger;
     }
 
     private List<PageNotFoundDetails> ConfiguredPages
@@ -51,7 +54,14 @@ public class PageNotFoundConfigService : IPageNotFoundService
         using var scope = scopeProvider.CreateScope(autoComplete: true);
         using var umbracoContext = umbracoContextFactory.EnsureUmbracoContext();
         var node = umbracoContext.UmbracoContext.Content?.GetById(nodeId);
-        return node != null && umbracoContext.UmbracoContext.Content != null
+
+        if (node == null)
+        {
+            LogNodeNotFoundById(nodeId);
+            return null;
+        }
+
+        return umbracoContext.UmbracoContext.Content != null
             ? GetNotFoundPage(node, true, umbracoContext.UmbracoContext.Content) : null;
     }
 
@@ -60,13 +70,30 @@ public class PageNotFoundConfigService : IPageNotFoundService
         using var scope = scopeProvider.CreateScope(autoComplete: true);
         using var umbracoContext = umbracoContextFactory.EnsureUmbracoContext();
         var node = umbracoContext.UmbracoContext.Content?.GetById(nodeKey);
-        
-        return node != null && umbracoContext.UmbracoContext.Content != null ? GetNotFoundPage(node, true, umbracoContext.UmbracoContext.Content) : null;
+
+        if (node == null)
+        {
+            LogNodeNotFoundByKey(nodeKey);
+            return null;
+        }
+
+        return umbracoContext.UmbracoContext.Content != null
+            ? GetNotFoundPage(node, true, umbracoContext.UmbracoContext.Content) : null;
     }
 
     private PageNotFoundDetails? GetNotFoundPage(IPublishedContent node, bool fetchInherited, IPublishedContentCache content)
     {
         var x = ConfiguredPages.FirstOrDefault(p => p.PageId == node.Key);
+
+        if (x != null)
+        {
+            LogConfigFound(node.Key, node.Name, x.Explicit404);
+        }
+        else
+        {
+            LogNoConfigForNode(node.Key, node.Name);
+        }
+
         x ??= new PageNotFoundDetails
             {
                 PageId = node.Key,
@@ -78,6 +105,7 @@ public class PageNotFoundConfigService : IPageNotFoundService
 
     public void RefreshCache()
     {
+        LogCacheRefresh();
         appPolicyCache.ClearByKey(CacheKey);
         appPolicyCache.Insert(CacheKey, LoadFromDb);
     }
@@ -92,6 +120,8 @@ public class PageNotFoundConfigService : IPageNotFoundService
 
     public async Task<PageNotFoundDetails> SetNotFoundPage(Guid parentKey, Guid pageNotFoundKey, bool refreshCache)
     {
+        LogSettingNotFoundPage(parentKey, pageNotFoundKey);
+
         using (var scope = scopeProvider.CreateScope())
         {
             var db = scope.Database;
@@ -100,24 +130,25 @@ public class PageNotFoundConfigService : IPageNotFoundService
             {
                 // create the page
                 await db.InsertAsync(new Models.DatabaseModels.PageNotFound { ParentId = parentKey, NotFoundPageId = pageNotFoundKey });
+                LogConfigCreated(parentKey, pageNotFoundKey);
             }
             else if (page != null)
             {
                 if (Guid.Empty.Equals(pageNotFoundKey))
                 {
                     await db.DeleteAsync(page);
+                    LogConfigDeleted(parentKey);
                 }
                 else
                 {
                     // update the existing page
                     page.NotFoundPageId = pageNotFoundKey;
                     db.Update(Models.DatabaseModels.PageNotFound.TableName, "ParentId", page);
+                    LogConfigUpdated(parentKey, pageNotFoundKey);
                 }
             }
 
             scope.Complete();
-
-            
         }
 
         if (refreshCache)
@@ -137,7 +168,7 @@ public class PageNotFoundConfigService : IPageNotFoundService
     {
         using var umbracoContext = umbracoContextFactory.EnsureUmbracoContext();
         var node = umbracoContext.UmbracoContext.Content?.GetById(nodeKey);
-        return node != null && umbracoContext.UmbracoContext.Content != null 
+        return node != null && umbracoContext.UmbracoContext.Content != null
             ? GetAncestor404(node, umbracoContext.UmbracoContext.Content)
             : null;
     }
@@ -146,9 +177,8 @@ public class PageNotFoundConfigService : IPageNotFoundService
     {
         if (node == null)
             return null;
-        //TODO: Need some logic, we don't want the whole tree just the first inherited 404
         var ancestor404 = GetNotFoundPage(node, false, content);
-        
+
         if((ancestor404 == null || !ancestor404.Has404()) && node.TryGetParent(documentNavigationQueryService, content, out var parent) && parent != null)
             return GetAncestor404(parent, content);
         return ancestor404;
@@ -160,10 +190,14 @@ public class PageNotFoundConfigService : IPageNotFoundService
         var sql = scope.SqlContext.Sql().Select("*").From<Models.DatabaseModels.PageNotFound>();
         var pages = scope.Database.Fetch<Models.DatabaseModels.PageNotFound>(sql);
         scope.Complete();
-        return pages.Select(p => new PageNotFoundDetails
+
+        var result = pages.Select(p => new PageNotFoundDetails
         {
             PageId = p.ParentId,
             Explicit404 = p.NotFoundPageId == Guid.Empty ? null : p.NotFoundPageId
         }).ToList();
+
+        LogLoadedFromDb(result.Count);
+        return result;
     }
 }

--- a/src/HC.PageNotFoundManager/ContentFinders/PageNotFoundFinder.Log.cs
+++ b/src/HC.PageNotFoundManager/ContentFinders/PageNotFoundFinder.Log.cs
@@ -1,0 +1,52 @@
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace HC.PageNotFoundManager.ContentFinders;
+
+public partial class PageNotFoundFinder
+{
+    [LoggerMessage(Level = LogLevel.Debug, Message = "PageNotFoundManager: Processing request for {Uri} (culture: {Culture})")]
+    private partial void LogRequestReceived(string uri, string? culture);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "PageNotFoundManager: Path {Uri} excluded by rule \"{MatchedPath}\" (configured paths: [{ExcludePaths}])")]
+    private partial void LogExcludedPath(string uri, string matchedPath, string excludePaths);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "PageNotFoundManager: No domain on request, resolved start node ID: {StartNodeId}")]
+    private partial void LogDomainResolved(int? startNodeId);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "PageNotFoundManager: Domain from request: {DomainName}, content ID: {ContentId}")]
+    private partial void LogDomainFromRequest(string domainName, int? contentId);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "PageNotFoundManager: Domain matched: {DomainName} (root content ID: {RootContentId})")]
+    private partial void LogDomainMatched(string domainName, int? rootContentId);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "PageNotFoundManager: No domain matched from {DomainCount} configured domain(s)")]
+    private partial void LogNoDomainMatched(int domainCount);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "PageNotFoundManager: No domains configured in Umbraco")]
+    private partial void LogNoDomainsConfigured();
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "PageNotFoundManager: Route resolution for \"{OriginalUri}\": stripped to \"{StrippedUri}\" → {DocumentKey}")]
+    private partial void LogRouteResolution(string originalUri, string strippedUri, Guid? documentKey);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "PageNotFoundManager: No content node found after stripping URI \"{Uri}\". Check that content is published and routes are up to date.")]
+    private partial void LogNoContentNodeFound(string uri);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "PageNotFoundManager: Closest content node: \"{Name}\" ({Key})")]
+    private partial void LogContentNodeFound(string name, Guid key);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "PageNotFoundManager: Config for {NodeKey}: Explicit404={Explicit404}, Inherited404={Inherited404}, resolved key={ResolvedKey}")]
+    private partial void LogNotFoundConfig(Guid nodeKey, Guid? explicit404, Guid? inherited404, Guid resolvedKey);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "PageNotFoundManager: Walking to parent: \"{Name}\" ({Key})")]
+    private partial void LogWalkingToParent(string name, Guid key);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "PageNotFoundManager: No 404 page configured for any ancestor of \"{Uri}\"")]
+    private partial void LogNo404PageConfigured(string uri);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "PageNotFoundManager: Serving 404 page \"{Name}\" ({Key}) for \"{Uri}\"")]
+    private partial void LogServing404Page(string name, Guid key, string uri);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "PageNotFoundManager: Error finding content for {RequestUri}")]
+    private partial void LogError(Exception ex, Uri requestUri);
+}

--- a/src/HC.PageNotFoundManager/ContentFinders/PageNotFoundFinder.cs
+++ b/src/HC.PageNotFoundManager/ContentFinders/PageNotFoundFinder.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using HC.PageNotFoundManager.Config;
@@ -14,7 +14,7 @@ using Umbraco.Cms.Core.Web;
 
 namespace HC.PageNotFoundManager.ContentFinders;
 
-public class PageNotFoundFinder : IContentLastChanceFinder
+public partial class PageNotFoundFinder : IContentLastChanceFinder
 {
     private readonly IPageNotFoundService config;
     private readonly PageNotFoundManagerSettings pageNotFoundManagerSettings;
@@ -55,59 +55,84 @@ public class PageNotFoundFinder : IContentLastChanceFinder
             //get domain name from Uri
             // find umbraco home node for uri's domain, and get the id of the node it is set on
 
-            if (pageNotFoundManagerSettings.ExcludePaths.Any(excludePath => uri.StartsWith(excludePath, StringComparison.OrdinalIgnoreCase)))
+            LogRequestReceived(uri, request.Culture);
+
+            var excludePaths = pageNotFoundManagerSettings.ExcludePaths;
+            if (excludePaths.Any(excludePath => uri.StartsWith(excludePath, StringComparison.OrdinalIgnoreCase)))
+            {
+                var matchedPath = excludePaths.First(p => uri.StartsWith(p, StringComparison.OrdinalIgnoreCase));
+                LogExcludedPath(uri, matchedPath, string.Join(", ", excludePaths.Select(p => $"\"{p}\"")));
                 return false;
+            }
 
             int? documentStartNodeId;
             if (request.Domain is null)
             {
                 documentStartNodeId = await GetDomain(request);
+                LogDomainResolved(documentStartNodeId);
             }
             else
             {
                 documentStartNodeId = request.Domain.ContentId;
+                LogDomainFromRequest(request.Domain.Name, documentStartNodeId);
             }
 
             using var umbracoContext = umbracoContextFactory.EnsureUmbracoContext();
 
             var documentKey = documentUrlService.GetDocumentKeyByRoute(uri, request.Culture, documentStartNodeId, false);
+
             while (documentKey == null && uri.Length > 0)
             {
                 uri = uri.Remove(uri.Length - 1, 1);
                 documentKey = documentUrlService.GetDocumentKeyByRoute(uri, request.Culture, documentStartNodeId, false);
             }
 
+            LogRouteResolution(request.AbsolutePathDecoded, uri, documentKey);
+
             var contentNode = documentKey != null ? umbracoContext.UmbracoContext.Content.GetById(documentKey!.Value) : null;
             if (contentNode == null)
             {
+                LogNoContentNodeFound(request.AbsolutePathDecoded);
                 return false;
             }
 
+            LogContentNodeFound(contentNode.Name, contentNode.Key);
+
             var nfp = config.GetNotFoundPage(documentKey!.Value);
             var nfpKey = nfp?.Explicit404 ?? nfp?.Inherited404?.Explicit404 ?? Guid.Empty;
+
+            LogNotFoundConfig(contentNode.Key, nfp?.Explicit404, nfp?.Inherited404?.Explicit404, nfpKey);
+
             var content = umbracoContext.UmbracoContext.Content.GetById(nfpKey);
 
             while (content == null && contentNode.TryGetParent(documentNavigationQueryService,
                 umbracoContext.UmbracoContext.Content, out var parent) && parent != null)
             {
                 contentNode = parent;
+                LogWalkingToParent(contentNode.Name, contentNode.Key);
+
                 nfp = config.GetNotFoundPage(contentNode.Key);
                 nfpKey = nfp?.Explicit404 ?? nfp?.Inherited404?.Explicit404 ?? Guid.Empty;
+
+                LogNotFoundConfig(contentNode.Key, nfp?.Explicit404, nfp?.Inherited404?.Explicit404, nfpKey);
+
                 content = umbracoContext.UmbracoContext.Content.GetById(nfpKey);
             }
 
             if (content == null)
             {
+                LogNo404PageConfigured(request.AbsolutePathDecoded);
                 return false;
             }
 
+            LogServing404Page(content.Name, content.Key, request.AbsolutePathDecoded);
             request.SetResponseStatus(404);
             request.SetPublishedContent(content);
             return true;
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "An error occurred in PageNotFoundFinder while trying to find content for request {RequestUri}", request.Uri);
+            LogError(ex, request.Uri);
             return false;
         }
     }
@@ -149,9 +174,15 @@ public class PageNotFoundFinder : IContentLastChanceFinder
 
             if (domain != null)
             {
-                // the domain has a RootContentId that we can use as the prefix.
+                LogDomainMatched(domain.DomainName, domain.RootContentId);
                 return domain.RootContentId;
             }
+
+            LogNoDomainMatched(domains.Count);
+        }
+        else
+        {
+            LogNoDomainsConfigured();
         }
 
         return null;


### PR DESCRIPTION
## Summary
- Adds source-generated `[LoggerMessage]` diagnostic logging to `PageNotFoundFinder` and `PageNotFoundConfigService`
- Covers the full 404 resolution flow: exclude path matching, domain resolution, route stripping, config lookups, ancestor walking, and the final result
- All logs prefixed with `PageNotFoundManager:` for easy filtering
- Uses `Debug` level for diagnostic flow, `Information` for config changes, `Warning` for failures

## Motivation
While debugging a 404 page not being served, we discovered there was no way to diagnose the issue without forking the package. The root cause turned out to be an empty string in `ExcludePaths` (from a misconfigured Azure SSO integration), which silently blocked all requests. The existing error-level catch block only fires on exceptions, not on logical failures.

With this logging enabled (`"HC.PageNotFoundManager": "Debug"`), the issue would have been immediately visible:

```
PageNotFoundManager: Path /c excluded by rule "" (configured paths: ["/umbraco-signin", "/umbraco-microsoft-signin/", ""])
```

## Enable logging
Add to your Serilog config:
```json
"Override": {
  "HC.PageNotFoundManager": "Debug"
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)